### PR TITLE
fix address comparison bug

### DIFF
--- a/src/Resources/views/storefront/page/checkout/order/wallee.html.twig
+++ b/src/Resources/views/storefront/page/checkout/order/wallee.html.twig
@@ -69,7 +69,9 @@
 
 								{% block page_checkout_confirm_address_billing_data %}
 									<div class="confirm-address-billing">
-										{% if billingAddress.id is same as(shippingAddress.id) %}
+										{% set shippingAddress = context.customer.activeShippingAddress %}
+					                                        {% set billingAddress = context.customer.activeBillingAddress %}
+					                                        {% if shippingAddress.id is defined and shippingAddress.id is same as(billingAddress.id) %}
 											{% block page_checkout_confirm_address_billing_data_equal %}
 												<p>
 													{{ "checkout.addressEqualText"|trans|sw_sanitize }}


### PR DESCRIPTION
billingAddress.id and shippingAddress.id are both null and therefore this comparison is always true. This leads to the display of a message that shipping and billing address are equal even if they are different.