### PR TITLE
Avoid redundant API calls per confirm-page view and degrade gracefully on API errors (#37)

### DIFF
--- a/src/Core/Checkout/PaymentMethod/SalesChannel/PaymentMethodRouteDecorator.php
+++ b/src/Core/Checkout/PaymentMethod/SalesChannel/PaymentMethodRouteDecorator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WalleePayment\Core\Checkout\PaymentMethod\SalesChannel;
 
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Payment\PaymentMethodDefinition;
 use Shopware\Core\Checkout\Payment\SalesChannel\AbstractPaymentMethodRoute;
 use Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRouteResponse;
@@ -35,6 +36,11 @@ class PaymentMethodRouteDecorator extends AbstractPaymentMethodRoute
     private PaymentMethodFilterService $paymentMethodFilterService;
 
     /**
+     * @var LoggerInterface
+     */
+    private LoggerInterface $logger;
+
+    /**
      * @param AbstractPaymentMethodRoute $decorated
      * @param PaymentMethodFilterService $paymentMethodFilterService
      */
@@ -44,6 +50,14 @@ class PaymentMethodRouteDecorator extends AbstractPaymentMethodRoute
     ) {
         $this->decorated = $decorated;
         $this->paymentMethodFilterService = $paymentMethodFilterService;
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
     }
 
     /**
@@ -83,10 +97,20 @@ class PaymentMethodRouteDecorator extends AbstractPaymentMethodRoute
         $paymentMethods = $response->getPaymentMethods();
 
         // Apply WhitelabelMachineName-specific filtering logic via the dedicated service.
-        $filteredCollection = $this->paymentMethodFilterService->filterPaymentMethods(
-            $paymentMethods,
-            $context
-        );
+        try {
+            $filteredCollection = $this->paymentMethodFilterService->filterPaymentMethods(
+                $paymentMethods,
+                $context
+            );
+        } catch (\Exception $e) {
+            // If the portal API cannot be reached, the customer must still be able to
+            // check out with the unfiltered method list - a possibly too broad list is
+            // better than failing the whole checkout page with an error.
+            $this->logger->error(
+                'Payment method filtering failed, returning unfiltered methods: ' . $e->getMessage()
+            );
+            return $response;
+        }
 
         // Return the filtered results as a new response.
         return new PaymentMethodRouteResponse(

--- a/src/Core/Checkout/Service/PaymentMethodFilterService.php
+++ b/src/Core/Checkout/Service/PaymentMethodFilterService.php
@@ -121,6 +121,21 @@ class PaymentMethodFilterService
             return $paymentMethodCollection;
         }
 
+        // If the available methods were already resolved during this request (e.g. the
+        // payment method route decorator ran before the storefront page event), reuse the
+        // cached result instead of repeating the same synchronous API calls. The cache is
+        // reset with an empty id list whenever cart or customer data changes
+        // (see TransactionManagementService::updateTempTransactionIfNeeded()).
+        $possibleMethods = $salesChannelContext->getContext()->getExtension('possibleMethods');
+        if ($possibleMethods instanceof ArrayEntity && !empty($possibleMethods->get('ids'))) {
+            return $this->buildFilteredCollection(
+                $paymentMethodCollection,
+                $possibleMethods->get('ids'),
+                $settings->getSpaceId(),
+                $salesChannelContext
+            );
+        }
+
         $source = $event;
         if ($source === null) {
             // In headless (Store API) flow, event is null. We explicitly fetch the cart to get line items.

--- a/src/Core/Checkout/Service/TransactionManagementService.php
+++ b/src/Core/Checkout/Service/TransactionManagementService.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace WalleePayment\Core\Checkout\Service;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use WalleePayment\Core\Api\Transaction\Service\TransactionService;
 use WalleePayment\Core\Settings\Service\SettingsService;
 use Wallee\Sdk\Model\TransactionState;
+use Wallee\Sdk\VersioningException;
 
 /**
  * This service manages the lifecycle of WhitelabelMachineName transactions and their state within the Shopware context.
@@ -36,6 +38,11 @@ class TransactionManagementService
     private CacheItemPoolInterface $cache;
 
     /**
+     * @var LoggerInterface
+     */
+    private LoggerInterface $logger;
+
+    /**
      * @param TransactionService $transactionService
      * @param SettingsService $settingsService
      * @param CacheItemPoolInterface $cache
@@ -48,6 +55,14 @@ class TransactionManagementService
         $this->transactionService = $transactionService;
         $this->settingsService = $settingsService;
         $this->cache = $cache;
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
     }
 
     /**
@@ -125,7 +140,21 @@ class TransactionManagementService
         if ($needsUpdate) {
             // Update the transaction in WhitelabelMachineName to reflect current cart and customer data.
             if ($transactionId) {
-                $this->transactionService->updateTempTransaction($salesChannelContext, $transactionId, $lineItems);
+                try {
+                    $this->transactionService->updateTempTransaction($salesChannelContext, $transactionId, $lineItems);
+                } catch (VersioningException $e) {
+                    // A concurrent request (e.g. a double tap or reload on the confirm page)
+                    // has already updated the same pending transaction with the current cart
+                    // data. The transaction is consistent on the portal side, so this request
+                    // can safely continue rendering instead of failing the whole page.
+                    $this->logger->info(
+                        sprintf(
+                            'Pending transaction %d was updated by a concurrent request, continuing: %s',
+                            $transactionId,
+                            $e->getMessage()
+                        )
+                    );
+                }
             }
 
             // Clear payment method cache as options might have changed due to address/currency change.

--- a/src/Resources/config/services/core/checkout_services.xml
+++ b/src/Resources/config/services/core/checkout_services.xml
@@ -10,6 +10,9 @@
 			<argument type="service" id="WalleePayment\Core\Settings\Service\SettingsService"/>
 			<!-- Cache for headless transaction persistence -->
 			<argument type="service" id="cache.system"/>
+			<call method="setLogger">
+				<argument type="service" id="monolog.logger.wallee_payment"/>
+			</call>
 		</service>
 
 		<service id="WalleePayment\Core\Checkout\Service\PaymentMethodFilterService">

--- a/src/Resources/config/services/core/store_api.xml
+++ b/src/Resources/config/services/core/store_api.xml
@@ -10,6 +10,9 @@
 				 decoration-inner-name="WalleePayment\Core\Checkout\PaymentMethod\SalesChannel\PaymentMethodRouteDecorator.inner">
 			<argument type="service" id="WalleePayment\Core\Checkout\PaymentMethod\SalesChannel\PaymentMethodRouteDecorator.inner"/>
 			<argument type="service" id="WalleePayment\Core\Checkout\Service\PaymentMethodFilterService"/>
+			<call method="setLogger">
+				<argument type="service" id="monolog.logger.wallee_payment"/>
+			</call>
 		</service>
 
 		<service id="WalleePayment\Core\Checkout\StoreApi\Route\WhitelabelMachineNameTransactionInfoRoute">


### PR DESCRIPTION
As offered in #37 — thank you for the review and for the opportunity to contribute this directly.

## What this PR does

Three focused changes, no behavioural change for the successful single-request path:

### 1. Reuse the already-resolved payment method availability within a request
`PaymentMethodFilterService` was already *writing* the allowed configuration ids into the `possibleMethods` context extension (and `TransactionManagementService::updateTempTransactionIfNeeded()` was already *invalidating* it with an empty id list on cart/customer changes) — but nothing ever *read* it. This PR adds the missing read: when the availability has already been resolved during the current request, `filterPaymentMethods()` rebuilds the collection from the cached ids instead of repeating the API round trips.

Effect on a storefront `/checkout/confirm` view: the route decorator (`onlyAvailable=1`) resolves availability once; the second pass via `CheckoutSubscriber` on `CheckoutConfirmPageLoadedEvent` then costs only local DB reads instead of repeating `transaction read` + `updateTempTransaction` + `fetchPaymentMethods`. In our production measurements (see #37: 1.3–3.0s per filtering pass) this roughly halves the payment-step latency.

### 2. Catch `VersioningException` on the temp-transaction update
Two parallel loads of the confirm page (mobile double-taps, back/forward navigation) race on `/transaction/update`; the loser crashed with an uncaught `Wallee\Sdk\VersioningException` and the customer got a 500 in the middle of checkout (~15 occurrences in our single shop since April, see #37). The race is benign — the concurrent request has already written the same cart data — so the losing request now logs at info level and continues rendering.

### 3. Graceful degradation in `PaymentMethodRouteDecorator`
`CheckoutSubscriber::onPageLoaded()` already guards its filtering with try/catch, but the Store API route decorator did not — so any API-side error (e.g. the HTTP 542 incident on 2026-07-13 documented in #37) took down every checkout page view for the duration of the outage. The decorator now mirrors the subscriber's guard: on failure it logs an error and returns the unfiltered (Shopware-rule-filtered) response, so the customer can still check out with the remaining methods.

## What this PR deliberately does not do

The remaining per-view `updateTempTransaction` call across *separate* requests (the `checkoutState` hashes live only in a per-request context extension) is untouched — persisting those hashes in the session/cache is a bigger design decision I'd rather leave to you, and change 2 removes its worst symptom.

## Validation

- `php -l` clean on all changed files (PHP 8.4), service XML validated.
- Logic verified against the production call chains documented in #37 (PostFinance Checkout whitelabel 7.3.2, Shopware 6.7.7.0). The repo has no test suite I could extend — happy to adjust anything to match your internal CI.

Closes: the redundant double-filtering and the customer-facing 500s from #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)